### PR TITLE
Fix compile error with msvc 2013

### DIFF
--- a/qtbindings/qtscript_uitools/qtscript_uitools.pro
+++ b/qtbindings/qtscript_uitools/qtscript_uitools.pro
@@ -3,5 +3,5 @@ include(../qtbindingsbase.pri)
 QT += uitools widgets
 SOURCES += plugin.cpp
 HEADERS += plugin.h
-INCLUDEPATH += ./include/ ${QTDIR}/lib/QtWidgets.framework/Headers
+INCLUDEPATH += ./include/
 include($$GENERATEDCPP/com_trolltech_qt_uitools/com_trolltech_qt_uitools.pri)


### PR DESCRIPTION
Tested with Qt5.6
BTW ${QTDIR} was not even expanded before the fix
