### PR TITLE
Fix building pp-iterator.h with gcc and clang

### DIFF
--- a/generator/parser/rpp/pp-iterator.h
+++ b/generator/parser/rpp/pp-iterator.h
@@ -84,7 +84,7 @@ public:
   inline pp_output_iterator &operator ++ () { return *this; }
   inline pp_output_iterator operator ++ (int) { return *this; }
   // Fix C2582 in MSVC2010/2012: http://stackoverflow.com/questions/2791525/stl-operator-behavior-change-with-visual-studio-2010
-  inline pp_output_iterator &operator=(const typename pp_output_iterator<_Container>& __v)
+  inline pp_output_iterator &operator=(const pp_output_iterator<_Container>& __v)
   {
     _M_result = __v._M_result;
     return *this;


### PR DESCRIPTION
Otherwise

```
parser/rpp/pp-iterator.h:87:55: error: expected a qualified name after 'typename'
  inline pp_output_iterator &operator=(const typename pp_output_iterator<_Container>& __v)
                                                      ^
```

And gcc emits a way more cryptic message:

```
parser/rpp/pp-iterator.h:87:84: error: declaration of 'operator=' as non-function
   inline pp_output_iterator &operator=(const typename pp_output_iterator<_Container>& __v)
                                                                                    ^
parser/rpp/pp-iterator.h:87:38: error: expected ';' at end of member declaration
   inline pp_output_iterator &operator=(const typename pp_output_iterator<_Container>& __v)
                                      ^
parser/rpp/pp-iterator.h:87:40: error: expected unqualified-id before 'const'
   inline pp_output_iterator &operator=(const typename pp_output_iterator<_Container>& __v)
                                        ^
parser/rpp/pp-iterator.h:87:40: error: expected ')' before 'const'
In file included from parser/rpp/pp.h:97:0,
                 from parser/rpp/preprocessor.cpp:50:
parser/rpp/pp-iterator.h:87:84: error: declaration of 'operator=' as non-function
   inline pp_output_iterator &operator=(const typename pp_output_iterator<_Container>& __v)
                                                                                    ^
parser/rpp/pp-iterator.h:87:38: error: expected ';' at end of member declaration
   inline pp_output_iterator &operator=(const typename pp_output_iterator<_Container>& __v)
                                      ^
parser/rpp/pp-iterator.h:87:40: error: expected unqualified-id before 'const'
   inline pp_output_iterator &operator=(const typename pp_output_iterator<_Container>& __v)
                                        ^
parser/rpp/pp-iterator.h:87:40: error: expected ')' before 'const'
```

Hopefully it doesn't break MSVC build. Sadly I don't have MSVC around to test.
